### PR TITLE
tests(article-labels): add tests for GET article-labels/articles

### DIFF
--- a/tests/api/article-labels/article-labels.article.id.get.spec.ts
+++ b/tests/api/article-labels/article-labels.article.id.get.spec.ts
@@ -1,0 +1,64 @@
+import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { createHeaders } from '@_src_helpers_api/create-token.helper';
+import { APIResponse, expect, test } from '@playwright/test';
+
+test.describe('GET article labels tests', async () => {
+  const articleLabels: string = `/api/article-labels/articles`;
+  const features: string = `/api/config/features`;
+  let setHeaders: { [key: string]: string };
+
+  test.beforeAll(async ({ request }) => {
+    setHeaders = await createHeaders();
+    //enable feature: labels
+    const response: APIResponse = await request.post(features, {
+      headers: setHeaders,
+      data: {
+        feature_labels: true,
+      },
+    });
+    expect(response.status()).toBe(HttpStatusCode.Ok);
+  });
+
+  test('Returns 200 OK after getting labels for existing article', async ({
+    request,
+  }) => {
+    //Given
+    const existingArticleId: number = 1;
+    // When
+    const response: APIResponse = await request.get(
+      `${articleLabels}/${existingArticleId}`,
+    );
+    const body = await response.json();
+
+    // Then
+    expect.soft(response.status()).toBe(HttpStatusCode.Ok);
+    expect.soft(body.id).toBeTruthy();
+    expect.soft(body.label_ids).toContain(1);
+    expect.soft(body.article_id).toBe(existingArticleId);
+  });
+
+  test('Returns 404 Not Found after getting labels for non-existing article', async ({
+    request,
+  }) => {
+    //Given
+    const nonExistingArticleId: number = 500000000;
+    // When
+    const response: APIResponse = await request.get(
+      `${articleLabels}/${nonExistingArticleId}`,
+    );
+
+    // Then
+    expect.soft(response.status()).toBe(HttpStatusCode.NotFound);
+  });
+
+  test.afterAll(async ({ request }) => {
+    //disable feature: labels
+    const response: APIResponse = await request.post(features, {
+      headers: setHeaders,
+      data: {
+        feature_labels: false,
+      },
+    });
+    expect(response.status()).toBe(HttpStatusCode.Ok);
+  });
+});

--- a/tests/api/article-labels/article-labels.article.id.get.spec.ts
+++ b/tests/api/article-labels/article-labels.article.id.get.spec.ts
@@ -32,7 +32,7 @@ test.describe('GET article labels tests', async () => {
 
     // Then
     expect.soft(response.status()).toBe(HttpStatusCode.Ok);
-    expect.soft(body.id).toBeTruthy();
+    expect.soft(typeof body.id === 'number').toBe(true);
     expect.soft(body.label_ids).toContain(1);
     expect.soft(body.article_id).toBe(existingArticleId);
   });

--- a/tests/api/articles/articles-post.spec.ts
+++ b/tests/api/articles/articles-post.spec.ts
@@ -41,7 +41,7 @@ test.describe('POST articles tests', async () => {
     expect.soft(responseBody.body).toBe(articleBody);
     expect.soft(responseBody.date).toBe(articleDate);
     expect.soft(responseBody.image).toBe(articleImage);
-    expect.soft(responseBody.id).toBeTruthy();
+    expect.soft(typeof responseBody.id === 'number').toBe(true);
   });
 
   test('Returns 400 Bad Request after sending malformed JSON', async ({

--- a/tests/api/comments/comments-post.spec.ts
+++ b/tests/api/comments/comments-post.spec.ts
@@ -34,7 +34,7 @@ test.describe('POST comments tests', async () => {
     expect(responseBody.article_id).toEqual(article_id);
     expect(responseBody.body).toBe(commentBody);
     expect(responseBody.date).toBe(commentDate);
-    expect(responseBody.id).toBeTruthy();
+    expect(typeof responseBody.id === 'number').toBe(true);
   });
 
   test('Returns 400 - Bad request after sending comment with malformed JSON', async ({


### PR DESCRIPTION
## Resolves #90 

### Scope of changes:

2 tests for GET article-labels/articles/{id} endpoint
This is one of special "features" that need to be enabled before using and are disabled by default.

### How to use it:

  N/A

## Any other comments?

There is a behaviour that I think is a bug, if article has no labels then we get 404 as well. We can discuss during the next meeting

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [x] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
