### PR TITLE
Tests/issue 99 add get users tests

### DIFF
--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
 import { logConsole } from '@_src_api/utils/log-levels';
+import { createHeaders } from '@_src_helpers_api/create-token.helper';
 import { APIResponse, expect, test } from '@playwright/test';
 
 test.describe('GET/users endpoint tests', async () => {
@@ -10,6 +11,20 @@ test.describe('GET/users endpoint tests', async () => {
     const response: APIResponse = await request.get(users);
     // Then
     expect(response.status()).toBe(HttpStatusCode.Ok);
+  });
+
+  test('Returns 200 OK - with authorization', async ({ request }) => {
+    const userTypes = ['regular', 'admin'];
+    for (const userType of userTypes) {
+      // Given
+      const setHeaders = await createHeaders(userType);
+      // When
+      const response: APIResponse = await request.get(users, {
+        headers: setHeaders,
+      });
+      // Then
+      expect(response.status()).toBe(HttpStatusCode.Ok);
+    }
   });
 
   test('Checks masking sensitive user data - without authorization', async ({

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -14,20 +14,6 @@ test.describe('GET/users endpoint tests', async () => {
     expect(response.status()).toBe(HttpStatusCode.Ok);
   });
 
-  test('Returns 200 OK - with authorization', async ({ request }) => {
-    const userTypes = ['regular', 'admin'];
-    for (const userType of userTypes) {
-      // Given
-      const setHeaders = await createHeaders(userType);
-      // When
-      const response: APIResponse = await request.get(users, {
-        headers: setHeaders,
-      });
-      // Then
-      expect(response.status()).toBe(HttpStatusCode.Ok);
-    }
-  });
-
   test('Checks masking sensitive user data - without authorization', async ({
     request,
   }) => {
@@ -46,11 +32,25 @@ test.describe('GET/users endpoint tests', async () => {
     });
   });
 
-  test('Checks masking sensitive user data - with authorization', async ({
-    request,
-  }) => {
-    const userTypes = ['regular', 'admin'];
-    for (const userType of userTypes) {
+  const userTypes = ['regular', 'admin'];
+
+  for (const userType of userTypes) {
+    test(`Returns 200 OK - with ${userType} user authorization`, async ({
+      request,
+    }) => {
+      // Given
+      const setHeaders = await createHeaders(userType);
+      // When
+      const response: APIResponse = await request.get(users, {
+        headers: setHeaders,
+      });
+      // Then
+      expect(response.status()).toBe(HttpStatusCode.Ok);
+    });
+
+    test(`Checks masking sensitive user data - with ${userType} user authorization`, async ({
+      request,
+    }) => {
       // Given
       const setHeaders = await createHeaders(userType);
       // When
@@ -68,6 +68,6 @@ test.describe('GET/users endpoint tests', async () => {
           logConsole(`Data leak for user: ${user.id}`);
         }
       });
-    }
-  });
+    });
+  }
 });

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -6,6 +6,7 @@ import { APIResponse, expect, test } from '@playwright/test';
 test.describe('GET/users endpoint tests', async () => {
   const users: string = '/api/users';
   const maskedData: string = '****';
+  const userTypes = ['regular', 'admin'];
 
   test('Returns 200 OK - without authorization', async ({ request }) => {
     // When
@@ -31,8 +32,6 @@ test.describe('GET/users endpoint tests', async () => {
       }
     });
   });
-
-  const userTypes = ['regular', 'admin'];
 
   for (const userType of userTypes) {
     test(`Returns 200 OK - with ${userType} user authorization`, async ({

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -4,9 +4,9 @@ import { createHeaders } from '@_src_helpers_api/create-token.helper';
 import { APIResponse, expect, test } from '@playwright/test';
 
 test.describe('GET/users endpoint tests', async () => {
-  const users: string = '/api/users';
   const maskedData: string = '****';
-  const userTypes = ['regular', 'admin'];
+  const users: string = '/api/users';
+  const userTypes: string[] = ['regular', 'admin'];
 
   test('Returns 200 OK - without authorization', async ({ request }) => {
     // When

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -5,6 +5,7 @@ import { APIResponse, expect, test } from '@playwright/test';
 
 test.describe('GET/users endpoint tests', async () => {
   const users: string = '/api/users';
+  const maskedData: string = '****';
 
   test('Returns 200 OK - without authorization', async ({ request }) => {
     // When
@@ -36,9 +37,9 @@ test.describe('GET/users endpoint tests', async () => {
     // Then
     responseBody.forEach((user) => {
       try {
-        expect(user.email).toEqual('****');
-        expect(user.lastname).toEqual('****');
-        expect(user.password).toEqual('****');
+        expect(user.email).toEqual(maskedData);
+        expect(user.lastname).toEqual(maskedData);
+        expect(user.password).toEqual(maskedData);
       } catch (error) {
         logConsole(`Data leak for user: ${user.id}`);
       }
@@ -60,9 +61,9 @@ test.describe('GET/users endpoint tests', async () => {
       // Then
       responseBody.forEach((user) => {
         try {
-          expect(user.email).toEqual('****');
-          expect(user.lastname).toEqual('****');
-          expect(user.password).toEqual('****');
+          expect(user.email).toEqual(maskedData);
+          expect(user.lastname).toEqual(maskedData);
+          expect(user.password).toEqual(maskedData);
         } catch (error) {
           logConsole(`Data leak for user: ${user.id}`);
         }

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -1,0 +1,15 @@
+import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { APIResponse, expect, test } from '@playwright/test';
+
+test.describe('GET/users endpoint tests', async () => {
+  const users: string = '/api/users';
+
+  test('Returns all users with 200 OK - without authorization', async ({
+    request,
+  }) => {
+    // When
+    const response: APIResponse = await request.get(users);
+    // Then
+    expect(response.status()).toBe(HttpStatusCode.Ok);
+  });
+});

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -44,4 +44,29 @@ test.describe('GET/users endpoint tests', async () => {
       }
     });
   });
+
+  test('Checks masking sensitive user data - with authorization', async ({
+    request,
+  }) => {
+    const userTypes = ['regular', 'admin'];
+    for (const userType of userTypes) {
+      // Given
+      const setHeaders = await createHeaders(userType);
+      // When
+      const response: APIResponse = await request.get(users, {
+        headers: setHeaders,
+      });
+      const responseBody = await response.json();
+      // Then
+      responseBody.forEach((user) => {
+        try {
+          expect(user.email).toEqual('****');
+          expect(user.lastname).toEqual('****');
+          expect(user.password).toEqual('****');
+        } catch (error) {
+          logConsole(`Data leak for user: ${user.id}`);
+        }
+      });
+    }
+  });
 });

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { logConsole } from '@_src_api/utils/log-levels';
 import { APIResponse, expect, test } from '@playwright/test';
 
 test.describe('GET/users endpoint tests', async () => {
@@ -19,9 +20,13 @@ test.describe('GET/users endpoint tests', async () => {
     const responseBody = await response.json();
     // Then
     responseBody.forEach((user) => {
-      expect(user.email).toEqual('****');
-      expect(user.lastname).toEqual('****');
-      expect(user.password).toEqual('****');
+      try {
+        expect(user.email).toEqual('****');
+        expect(user.lastname).toEqual('****');
+        expect(user.password).toEqual('****');
+      } catch (error) {
+        logConsole(`Data leak for user: ${user.id}`);
+      }
     });
   });
 });

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -4,12 +4,24 @@ import { APIResponse, expect, test } from '@playwright/test';
 test.describe('GET/users endpoint tests', async () => {
   const users: string = '/api/users';
 
-  test('Returns all users with 200 OK - without authorization', async ({
-    request,
-  }) => {
+  test('Returns 200 OK - without authorization', async ({ request }) => {
     // When
     const response: APIResponse = await request.get(users);
     // Then
     expect(response.status()).toBe(HttpStatusCode.Ok);
+  });
+
+  test('Checks masking sensitive user data - without authorization', async ({
+    request,
+  }) => {
+    // When
+    const response: APIResponse = await request.get(users);
+    const responseBody = await response.json();
+    // Then
+    responseBody.forEach((user) => {
+      expect(user.email).toEqual('****');
+      expect(user.lastname).toEqual('****');
+      expect(user.password).toEqual('****');
+    });
   });
 });


### PR DESCRIPTION
## Resolves #99 

### Scope of changes:

Added:
- Simple test for returning 200 OK for GET users
- Additional test for checking if sensitive data are masked in the response

Each test is provided in two versions - without and with authorization

## Any other comments?

I've decided to use loops in the tests to run the test separately for admin and for regular user, as well as to run the masking test separately for each user in database.

Any comments appreciated - maybe my solution is not the best one

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [ ] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
