### PR TITLE
[Issue 65] Create user using faker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "kawqa-gad-playwright",
       "dependencies": {
         "@axe-core/playwright": "^4.9.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.2.0",
         "@playwright/test": "^1.46.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/node": "^20.8.7",
@@ -566,6 +566,23 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.2.0.tgz",
+      "integrity": "sha512-ulqQu4KMr1/sTFIYvqSdegHT8NIkt66tFAkugGnHA+1WAfEn6hMzNR+svjXGFRVLnapxvej67Z/LwchFrnLBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2317,7 +2334,6 @@
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
       "integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@faker-js/faker": "^9.2.0",
     "@playwright/test": "^1.46.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20.8.7",

--- a/src/api/enums/user-types.enum.ts
+++ b/src/api/enums/user-types.enum.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-unused-vars */
+
+export enum UserType {
+  regular = 'regular',
+  admin = 'admin',
+  custom = 'custom',
+}

--- a/src/api/enums/user-types.enum.ts
+++ b/src/api/enums/user-types.enum.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 export enum UserType {
   regular = 'regular',
   admin = 'admin',

--- a/src/helpers/api/create-token.helper.ts
+++ b/src/helpers/api/create-token.helper.ts
@@ -19,6 +19,9 @@ export async function createToken(userType: string): Promise<string> {
     const userData: UserData = await createUser(tokenContextRequest);
     setEmail = userData.email;
     setPassword = userData.password;
+    logConsole(
+      `Logging in as ${userType} user ${userData.firstname} ${userData.lastname} (email: ${setEmail})\n`,
+    );
   }
 
   const response = await tokenContextRequest.post(`/api/login`, {

--- a/src/helpers/api/create-token.helper.ts
+++ b/src/helpers/api/create-token.helper.ts
@@ -1,10 +1,13 @@
+import { createUser } from './create-user.helper';
 import { UserType } from '@_src_api/enums/user-types.enum';
 import { logConsole } from '@_src_api/utils/log-levels';
 import { testUsers } from '@_src_fixtures_api/auth';
 import { request } from '@playwright/test';
+import { UserData } from 'test-data/models/user.model';
 
 export async function createToken(userType: string): Promise<string> {
   let setEmail: string, setPassword: string;
+  const tokenContextRequest = await request.newContext();
 
   if (userType === UserType.regular) {
     setEmail = testUsers.regularUser.email;
@@ -12,9 +15,12 @@ export async function createToken(userType: string): Promise<string> {
   } else if (userType === UserType.admin) {
     setEmail = testUsers.admin.email;
     setPassword = testUsers.admin.password;
+  } else if (userType === UserType.custom) {
+    const userData: UserData = await createUser(tokenContextRequest);
+    setEmail = userData.email;
+    setPassword = userData.password;
   }
 
-  const tokenContextRequest = await request.newContext();
   const response = await tokenContextRequest.post(`/api/login`, {
     data: {
       email: setEmail,

--- a/src/helpers/api/create-token.helper.ts
+++ b/src/helpers/api/create-token.helper.ts
@@ -1,14 +1,15 @@
+import { UserType } from '@_src_api/enums/user-types.enum';
 import { logConsole } from '@_src_api/utils/log-levels';
 import { testUsers } from '@_src_fixtures_api/auth';
 import { request } from '@playwright/test';
 
 export async function createToken(userType: string): Promise<string> {
-  let setEmail, setPassword;
+  let setEmail: string, setPassword: string;
 
-  if (userType === 'regular') {
+  if (userType === UserType.regular) {
     setEmail = testUsers.regularUser.email;
     setPassword = testUsers.regularUser.password;
-  } else if (userType === 'admin') {
+  } else if (userType === UserType.admin) {
     setEmail = testUsers.admin.email;
     setPassword = testUsers.admin.password;
   }
@@ -27,7 +28,7 @@ export async function createToken(userType: string): Promise<string> {
 }
 
 export async function createHeaders(
-  userType: string = 'regular',
+  userType: string = UserType.regular,
 ): Promise<{ [key: string]: string }> {
   const setTokenInHeaders = await createToken(userType);
   const requestHeaders = {

--- a/src/helpers/api/create-user.helper.ts
+++ b/src/helpers/api/create-user.helper.ts
@@ -1,0 +1,22 @@
+import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { APIRequestContext, expect } from '@playwright/test';
+import { UserData } from 'test-data/models/user.model';
+import { generateFakeUserData } from 'test-data/shared/user.generator';
+
+export async function createUser(
+  request: APIRequestContext,
+): Promise<UserData> {
+  // Given
+  const userData = await generateFakeUserData(request);
+
+  //When
+  const response = await request.post(`api/users`, {
+    data: userData,
+  });
+
+  //Then
+  const code = response.status();
+  expect(code).toBe(HttpStatusCode.Created);
+
+  return userData;
+}

--- a/test-data/models/user.model.ts
+++ b/test-data/models/user.model.ts
@@ -1,0 +1,7 @@
+export interface UserData {
+  email: string;
+  firstname: string;
+  lastname: string;
+  password: string;
+  avatar: string;
+}

--- a/test-data/shared/user.generator.ts
+++ b/test-data/shared/user.generator.ts
@@ -5,9 +5,12 @@ import { UserData } from 'test-data/models/user.model';
 export async function generateFakeUserData(
   request: APIRequestContext,
 ): Promise<UserData> {
-  const userEmail = faker.internet.email();
-  const userFirstName = faker.person.firstName();
-  const userLastName = faker.person.lastName();
+  const userFirstName = faker.person.firstName().replace(/[^A-Za-z]/g, '');
+  const userLastName = faker.person.lastName().replace(/[^A-Za-z]/g, '');
+  const userEmail = faker.internet.email({
+    firstName: userFirstName,
+    lastName: userLastName,
+  });
   const userPassword = faker.internet.password();
   const avatarImage = await getRandomAvatarImage(request);
   const userAvatar = `.\\data\\users\\${avatarImage}`;

--- a/test-data/shared/user.generator.ts
+++ b/test-data/shared/user.generator.ts
@@ -6,7 +6,11 @@ export async function generateFakeUserData(
   request: APIRequestContext,
 ): Promise<UserData> {
   const userFirstName = faker.person.firstName().replace(/[^A-Za-z]/g, '');
-  const userLastName = faker.person.lastName().replace(/[^A-Za-z]/g, '');
+  let userLastName = faker.person.lastName().replace(/[^A-Za-z]/g, '');
+  // randomly generate names with a hyphen
+  if (Math.random() < 0.5) {
+    userLastName += '-' + faker.person.lastName().replace(/[^A-Za-z]/g, '');
+  }
   const userEmail = faker.internet.email({
     firstName: userFirstName,
     lastName: userLastName,

--- a/test-data/shared/user.generator.ts
+++ b/test-data/shared/user.generator.ts
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker/locale/en';
+import { APIRequestContext, APIResponse } from '@playwright/test';
+import { UserData } from 'test-data/models/user.model';
+
+export async function generateFakeUserData(
+  request: APIRequestContext,
+): Promise<UserData> {
+  const userEmail = faker.internet.email();
+  const userFirstName = faker.person.firstName();
+  const userLastName = faker.person.lastName();
+  const userPassword = faker.internet.password();
+  const avatarImage = await getRandomAvatarImage(request);
+  const userAvatar = `.\\data\\users\\${avatarImage}`;
+
+  const userData: UserData = {
+    email: userEmail,
+    firstname: userFirstName,
+    lastname: userLastName,
+    password: userPassword,
+    avatar: userAvatar,
+  };
+
+  return userData;
+}
+
+async function getRandomAvatarImage(
+  request: APIRequestContext,
+): Promise<string> {
+  const getAllAvatars: APIResponse = await request.get(`/api/images/user`);
+  const allAvatars = await getAllAvatars.json();
+  const randomAvatar =
+    allAvatars[Math.floor(Math.random() * allAvatars.length)];
+  return randomAvatar;
+}

--- a/tests/api/articles/articles-id-delete.spec.ts
+++ b/tests/api/articles/articles-id-delete.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { UserType } from '@_src_api/enums/user-types.enum';
 import { testUsers } from '@_src_fixtures_api/auth';
 import { createHeaders } from '@_src_helpers_api/create-token.helper';
 import { APIResponse, expect, test } from '@playwright/test';
@@ -87,7 +88,7 @@ test.describe('DELETE articles/{id}', () => {
       .toBe(HttpStatusCode.Ok);
 
     // When admin user tries to delete the article
-    setHeaders = await createHeaders('admin');
+    setHeaders = await createHeaders(UserType.admin);
     const response = await request.delete(`${articles}/${createdArticleId}`, {
       headers: setHeaders,
     });
@@ -100,7 +101,7 @@ test.describe('DELETE articles/{id}', () => {
     request,
   }) => {
     // Given the article is created by other user (admin)
-    setHeaders = await createHeaders('admin');
+    setHeaders = await createHeaders(UserType.admin);
 
     const createResponse: APIResponse = await request.post(articles, {
       headers: setHeaders,

--- a/tests/api/articles/articles-id-patch.spec.ts
+++ b/tests/api/articles/articles-id-patch.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { UserType } from '@_src_api/enums/user-types.enum';
 import { logConsole } from '@_src_api/utils/log-levels';
 import { testUsers } from '@_src_fixtures_api/auth';
 import {
@@ -21,7 +22,7 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
     randomNumber = Math.random().toString();
     newTitle = `How to start writing effective test cases in Gherkin ${randomNumber}`;
     setHeaders = await createHeaders();
-    setHeadersForRegularUser = await createHeaders('regular');
+    setHeadersForRegularUser = await createHeaders(UserType.regular);
   });
 
   test('Returns 200 OK when updating article', async ({ request }) => {
@@ -148,8 +149,9 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
     request,
   }) => {
     // Given
-    const setHeadersForAdmin: { [key: string]: string } =
-      await createHeaders('admin');
+    const setHeadersForAdmin: { [key: string]: string } = await createHeaders(
+      UserType.admin,
+    );
 
     // When
     const response: APIResponse = await request.patch(`${articles}/2`, {

--- a/tests/api/comments/comments-patch.spec.ts
+++ b/tests/api/comments/comments-patch.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { UserType } from '@_src_api/enums/user-types.enum';
 import { testUsers } from '@_src_fixtures_api/auth';
 import {
   createHeaders,
@@ -14,7 +15,7 @@ test.describe('PATCH comments/{id} endpoint tests', async () => {
   const newComment: string = 'I changed my mind';
 
   test.beforeAll(async () => {
-    setHeadersForRegularUser = await createHeaders('regular');
+    setHeadersForRegularUser = await createHeaders(UserType.regular);
     setNewCommentId = await createNewComment(setHeadersForRegularUser, 1);
   });
 

--- a/tests/api/quiz/quiz-questions-get.spec.ts
+++ b/tests/api/quiz/quiz-questions-get.spec.ts
@@ -1,0 +1,40 @@
+import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { UserType } from '@_src_api/enums/user-types.enum';
+import { createHeaders } from '@_src_helpers_api/create-token.helper';
+import test, { APIResponse, expect } from '@playwright/test';
+
+test.describe('GET quiz questions endpoint tests', async () => {
+  const quizQuestions: string = '/api/quiz/questions';
+  const errorKey: string = 'error';
+
+  test('Returns 401 Unauthorized without authorization', async ({
+    request,
+  }) => {
+    //Given
+    const errorMessage = 'Access token not provided!';
+
+    // When
+    const response: APIResponse = await request.get(quizQuestions);
+
+    // Then
+    const responseBody = await response.json();
+    expect.soft(response.status()).toBe(HttpStatusCode.Unauthorized);
+    expect.soft(Object.keys(responseBody)).toContain(errorKey);
+    expect.soft(responseBody.error.message).toEqual(errorMessage);
+  });
+
+  test('Returns 200 OK with authorization', async ({ request }) => {
+    //Given
+    const setHeaders = await createHeaders(UserType.custom);
+    // When
+    const response: APIResponse = await request.get(quizQuestions, {
+      headers: setHeaders,
+    });
+
+    // Then
+    const responseBody = await response.json();
+    expect.soft(response.status()).toBe(HttpStatusCode.Ok);
+    expect.soft(Object.keys(responseBody)).not.toContain(errorKey);
+    expect.soft(Object.keys(responseBody).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/api/quiz/quiz-questions-get.spec.ts
+++ b/tests/api/quiz/quiz-questions-get.spec.ts
@@ -7,6 +7,21 @@ test.describe('GET quiz questions endpoint tests', async () => {
   const quizQuestions: string = '/api/quiz/questions';
   const errorKey: string = 'error';
 
+  test('Returns 200 OK with authorization', async ({ request }) => {
+    //Given
+    const setHeaders = await createHeaders(UserType.custom);
+    // When
+    const response: APIResponse = await request.get(quizQuestions, {
+      headers: setHeaders,
+    });
+
+    // Then
+    const responseBody = await response.json();
+    expect.soft(response.status()).toBe(HttpStatusCode.Ok);
+    expect.soft(Object.keys(responseBody)).not.toContain(errorKey);
+    expect.soft(Object.keys(responseBody).length).toBeGreaterThan(0);
+  });
+
   test('Returns 401 Unauthorized without authorization', async ({
     request,
   }) => {
@@ -21,20 +36,5 @@ test.describe('GET quiz questions endpoint tests', async () => {
     expect.soft(response.status()).toBe(HttpStatusCode.Unauthorized);
     expect.soft(Object.keys(responseBody)).toContain(errorKey);
     expect.soft(responseBody.error.message).toEqual(errorMessage);
-  });
-
-  test('Returns 200 OK with authorization', async ({ request }) => {
-    //Given
-    const setHeaders = await createHeaders(UserType.custom);
-    // When
-    const response: APIResponse = await request.get(quizQuestions, {
-      headers: setHeaders,
-    });
-
-    // Then
-    const responseBody = await response.json();
-    expect.soft(response.status()).toBe(HttpStatusCode.Ok);
-    expect.soft(Object.keys(responseBody)).not.toContain(errorKey);
-    expect.soft(Object.keys(responseBody).length).toBeGreaterThan(0);
   });
 });

--- a/tests/api/users/users-get.spec.ts
+++ b/tests/api/users/users-get.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
+import { UserType } from '@_src_api/enums/user-types.enum';
 import { logConsole } from '@_src_api/utils/log-levels';
 import { createHeaders } from '@_src_helpers_api/create-token.helper';
 import { APIResponse, expect, test } from '@playwright/test';
@@ -6,7 +7,7 @@ import { APIResponse, expect, test } from '@playwright/test';
 test.describe('GET/users endpoint tests', async () => {
   const maskedData: string = '****';
   const users: string = '/api/users';
-  const userTypes: string[] = ['regular', 'admin'];
+  const userTypes: string[] = [UserType.regular, UserType.admin];
 
   test('Returns 200 OK - without authorization', async ({ request }) => {
     // When


### PR DESCRIPTION
## Resolves #65 

### Scope of changes:

1. I added logic for creating a custom user (with fake data), logging in, and using the token for this user in tests
2. I created a sample test using the new logic

Detailed description:
The new logic uses the new `createUser` function from the `create-user.helper.ts` file.
The `createUser` function uses the new `generateFakeUserData` function which generates user data using faker (avatar is randomly selected from images available in GAD)
The generated user data are consistent with the new `UserData` interface in the `user.model.ts` file.

Additional improvements:
To ensure the user type is correctly stated, I added a new enum (`UserType`) and replaced all instances of `regular` and `admin` with this new enum.

### How to use it:

**To test as a custom user**, create headers with the `UserType.custom` parameter, e.g.

```typescript
const setHeaders = await createHeaders(UserType.custom);
```

In general, **to explicitly state the user type** for creating headers, use the new enum, e.g. instead of `createHeaders('admin')` now you have to use `createHeaders(UserType.admin)`.

#### Faker: 

First install the faker library: `npm i @faker-js/faker`

To use the faker, import it (I suggest importing only EN version to improve test performance):

```typescript
import {faker } from '@faker-js/faker/locale/en'
```

## Any other comments?

See the exemplary test `GET quiz questions endpoint tests › Returns 200 OK with authorization` to check, how it works.

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [x] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
