### PR TITLE
[ISSUE-127]add-tests-for-gui-practise-page-simple-elements-with-ids-subpage

### DIFF
--- a/src/gui/pages/practice-page.page.ts
+++ b/src/gui/pages/practice-page.page.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export class PracticePage {
+  protected page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async textAreaStretching(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+  ): Promise<void> {
+    await this.page.mouse.move(startX, startY);
+    await this.page.mouse.down();
+    await this.page.mouse.move(endX, endY, { steps: 10 });
+    await this.page.mouse.up();
+  }
+}

--- a/src/gui/pages/simple-elements-with-ids.page.ts
+++ b/src/gui/pages/simple-elements-with-ids.page.ts
@@ -1,6 +1,8 @@
-import { Locator, Page } from '@playwright/test';
+import { PracticePage } from './practice-page.page';
+import { Page } from '@playwright/test';
+import { Locator } from '@playwright/test';
 
-export class SimpleElementsWithIdsPage {
+export class SimpleElementsWithIdsPage extends PracticePage {
   readonly label: Locator;
   readonly button: Locator;
   readonly checkbox: Locator;
@@ -16,7 +18,8 @@ export class SimpleElementsWithIdsPage {
   readonly colorInput: Locator;
   readonly resultsArea: Locator;
 
-  constructor(private page: Page) {
+  constructor(page: Page) {
+    super(page);
     this.label = this.page.getByTestId('dti-label-element');
     this.button = this.page.getByTestId('dti-button-element');
     this.checkbox = this.page.getByTestId('dti-checkbox');
@@ -31,16 +34,5 @@ export class SimpleElementsWithIdsPage {
     this.dateInput = this.page.getByTestId('dti-date');
     this.colorInput = this.page.getByTestId('dti-color');
     this.resultsArea = this.page.getByTestId('dti-results');
-  }
-  async textAreaStretching(
-    startX: number,
-    startY: number,
-    endX: number,
-    endY: number,
-  ): Promise<void> {
-    await this.page.mouse.move(startX, startY);
-    await this.page.mouse.down();
-    await this.page.mouse.move(endX, endY, { steps: 10 });
-    await this.page.mouse.up();
   }
 }

--- a/src/gui/pages/simple-elements-with-ids.page.ts
+++ b/src/gui/pages/simple-elements-with-ids.page.ts
@@ -1,6 +1,5 @@
 import { PracticePage } from './practice-page.page';
-import { Page } from '@playwright/test';
-import { Locator } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 export class SimpleElementsWithIdsPage extends PracticePage {
   readonly label: Locator;

--- a/src/gui/pages/simple-elements-with-ids.page.ts
+++ b/src/gui/pages/simple-elements-with-ids.page.ts
@@ -1,0 +1,46 @@
+import { Locator, Page } from '@playwright/test';
+
+export class SimpleElementsWithIdsPage {
+  readonly label: Locator;
+  readonly button: Locator;
+  readonly checkbox: Locator;
+  readonly input: Locator;
+  readonly textArea: Locator;
+  readonly dropDownList: Locator;
+  readonly radioButtonFirst: Locator;
+  readonly radioButtonSecond: Locator;
+  readonly radioButtonThird: Locator;
+  readonly rangeBar: Locator;
+  readonly tooltip: Locator;
+  readonly dateInput: Locator;
+  readonly colorInput: Locator;
+  readonly resultsArea: Locator;
+
+  constructor(private page: Page) {
+    this.label = this.page.getByTestId('dti-label-element');
+    this.button = this.page.getByTestId('dti-button-element');
+    this.checkbox = this.page.getByTestId('dti-checkbox');
+    this.input = this.page.getByTestId('dti-input');
+    this.textArea = this.page.getByTestId('dti-textarea');
+    this.dropDownList = this.page.getByTestId('dti-dropdown');
+    this.radioButtonFirst = this.page.getByTestId('dti-radio1');
+    this.radioButtonSecond = this.page.getByTestId('dti-radio2');
+    this.radioButtonThird = this.page.getByTestId('dti-radio3');
+    this.rangeBar = this.page.getByTestId('dti-range');
+    this.tooltip = this.page.getByTestId('dti-tooltip-element');
+    this.dateInput = this.page.getByTestId('dti-date');
+    this.colorInput = this.page.getByTestId('dti-color');
+    this.resultsArea = this.page.getByTestId('dti-results');
+  }
+  async textAreaStretching(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+  ): Promise<void> {
+    await this.page.mouse.move(startX, startY);
+    await this.page.mouse.down();
+    await this.page.mouse.move(endX, endY, { steps: 10 });
+    await this.page.mouse.up();
+  }
+}

--- a/src/helpers/gui/color-utils.helper.ts
+++ b/src/helpers/gui/color-utils.helper.ts
@@ -1,0 +1,8 @@
+//Function to convert color from HEX to RGB
+export function hexToRgb(hex: string): string {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `${r}, ${g}, ${b}`;
+}

--- a/src/helpers/gui/color-utils.helper.ts
+++ b/src/helpers/gui/color-utils.helper.ts
@@ -1,8 +1,7 @@
-//Function to convert color from HEX to RGB
+// //Function to convert color from HEX to RGB
 export function hexToRgb(hex: string): string {
-  const bigint = parseInt(hex.slice(1), 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
   return `${r}, ${g}, ${b}`;
 }

--- a/tests/gui-practice/simple-elements/with-ids.spec.ts
+++ b/tests/gui-practice/simple-elements/with-ids.spec.ts
@@ -1,0 +1,189 @@
+import { expect, test } from '@playwright/test';
+import { SimpleElementsWithIdsPage } from 'src/gui/pages/simple-elements-with-ids.page';
+import { hexToRgb } from 'src/helpers/gui/color-utils.helper';
+
+test.describe('GUI tests for practice page - simple elements with IDs', () => {
+  let simpleElementsWithIdsPage: SimpleElementsWithIdsPage;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/practice/simple-elements.html');
+    simpleElementsWithIdsPage = new SimpleElementsWithIdsPage(page);
+  });
+
+  test('Label test', async ({ page }) => {
+    // Given
+    const labelText = 'Some text for label';
+    // Then
+    expect(simpleElementsWithIdsPage.label).toHaveText(labelText);
+  });
+
+  test('Button test', async ({ page }) => {
+    // Given
+    const resultText = 'You clicked the button!';
+    // When
+    await simpleElementsWithIdsPage.button.click();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+
+  test('Checkbox checked test', async ({ page }) => {
+    // Given
+    const resultText = 'Checkbox is checked!';
+    // When
+    await simpleElementsWithIdsPage.checkbox.check();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Checkbox unchecked test', async ({ page }) => {
+    // Given
+    const resultText = 'Checkbox is unchecked!';
+    // When
+    await simpleElementsWithIdsPage.checkbox.check();
+    await simpleElementsWithIdsPage.checkbox.uncheck();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Typing correct value into input area test', async ({ page }) => {
+    // Given
+    const inputText = 'test';
+    const resultText = `Input value changed to: ${inputText}`;
+    // When
+    await simpleElementsWithIdsPage.input.fill(inputText);
+    await simpleElementsWithIdsPage.input.blur();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Typing correct value into input area without blur test', async ({
+    page,
+  }) => {
+    // Given
+    const inputText = 'test';
+    // When
+    await simpleElementsWithIdsPage.input.fill(inputText);
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toBeEmpty;
+  });
+  test('Typing too long value into input area test', async ({ page }) => {
+    // Given
+    const inputText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod';
+    const correctText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ';
+    const resultText = `Input value changed to: ${correctText}`;
+    // When
+    await simpleElementsWithIdsPage.input.fill(inputText);
+    await simpleElementsWithIdsPage.input.blur();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Stretching the text area test', async ({ page }) => {
+    //
+    const boundingBoxBefore =
+      await simpleElementsWithIdsPage.textArea.boundingBox();
+    const startX = boundingBoxBefore.x + boundingBoxBefore.width - 5;
+    const startY = boundingBoxBefore.y + boundingBoxBefore.height - 5;
+    const endX = startX + 50;
+    const endY = startY + 50;
+    // When
+    await simpleElementsWithIdsPage.textAreaStretching(
+      startX,
+      startY,
+      endX,
+      endY,
+    );
+    const boundingBoxAfter =
+      await simpleElementsWithIdsPage.textArea.boundingBox();
+    // Then
+    expect(boundingBoxAfter.width).toBeGreaterThan(boundingBoxBefore.width);
+    expect(boundingBoxAfter.height).toBeGreaterThan(boundingBoxBefore.height);
+  });
+  test('Typing correct value into text area test', async ({ page }) => {
+    // Given
+    const inputText = 'test';
+    const resultText = `Textarea value changed to: ${inputText}`;
+    // When
+    await simpleElementsWithIdsPage.textArea.fill(inputText);
+    await simpleElementsWithIdsPage.textArea.blur();
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Dropdown list test', async ({ page }) => {
+    // Given
+    const options = ['option2', 'option3', 'option1'];
+    const resultText = options.map((option) => `Selected option: ${option}`);
+    // When
+    for (let i = 0; i < options.length; i++) {
+      await simpleElementsWithIdsPage.dropDownList.selectOption(options[i]);
+      // Then
+      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+    }
+  });
+  test('RadioButtons test', async ({ page }) => {
+    // Given
+    const radioButtons = [
+      simpleElementsWithIdsPage.radioButtonFirst,
+      simpleElementsWithIdsPage.radioButtonSecond,
+      simpleElementsWithIdsPage.radioButtonThird,
+    ];
+    const resultText = [
+      'Radio Button 1 clicked!',
+      'Radio Button 2 clicked!',
+      'Radio Button 3 clicked!',
+    ];
+    // When
+    for (let i = 0; i < radioButtons.length; i++) {
+      await radioButtons[i].click();
+      // Then
+      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+    }
+  });
+  test('Range bar test', async ({ page }) => {
+    // Given
+    const ranges = ['50', '100', '0'];
+    const resultText = ranges.map(
+      (range) => `Range value changed to: ${range}`,
+    );
+    // When
+    for (let i = 0; i < ranges.length; i++) {
+      await simpleElementsWithIdsPage.rangeBar.fill(ranges[i]);
+      // Then
+      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+    }
+  });
+  test('Label with mouse hover test', async ({ page }) => {
+    // Given
+    const resultText = 'Mouse over event occurred!';
+    // When
+    await simpleElementsWithIdsPage.tooltip.hover();
+
+    // Then
+    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+  });
+  test('Select date test', async ({ page }) => {
+    // Given
+    const dates = ['2024-06-05', '2022-02-09', '2023-04-02'];
+    const resultText = dates.map((date) => `Selected date: ${date}`);
+    //When
+    for (let i = 0; i < dates.length; i++) {
+      await simpleElementsWithIdsPage.dateInput.fill(dates[i]);
+      // Then
+      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+    }
+  });
+  test('Colors picker test', async ({ page }) => {
+    // Given
+    const colors = ['#d02525', '#1a7431', '#e07ee7'];
+    const resultText = colors.map(
+      (color) =>
+        `New selected color: ${color} as hex and in RGB: rgb(${hexToRgb(
+          color,
+        )})`,
+    );
+    //When
+    for (let i = 0; i < colors.length; i++) {
+      await simpleElementsWithIdsPage.colorInput.fill(colors[i]);
+      // Then
+      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+    }
+  });
+});

--- a/tests/gui/simple-elements/with-ids.spec.ts
+++ b/tests/gui/simple-elements/with-ids.spec.ts
@@ -10,40 +10,42 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     simpleElementsWithIdsPage = new SimpleElementsWithIdsPage(page);
   });
 
-  test('Label test', async ({ page }) => {
+  test('Label test', async ({}) => {
     // Given
     const labelText = 'Some text for label';
     // Then
-    expect(simpleElementsWithIdsPage.label).toHaveText(labelText);
+    await expect(simpleElementsWithIdsPage.label).toHaveText(labelText);
   });
 
-  test('Button test', async ({ page }) => {
+  test('Button test', async ({}) => {
     // Given
     const resultText = 'You clicked the button!';
     // When
     await simpleElementsWithIdsPage.button.click();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
 
-  test('Checkbox checked test', async ({ page }) => {
+  test('Checkbox checked test', async ({}) => {
     // Given
     const resultText = 'Checkbox is checked!';
     // When
     await simpleElementsWithIdsPage.checkbox.check();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Checkbox unchecked test', async ({ page }) => {
+
+  test('Checkbox unchecked test', async ({}) => {
     // Given
     const resultText = 'Checkbox is unchecked!';
     // When
     await simpleElementsWithIdsPage.checkbox.check();
     await simpleElementsWithIdsPage.checkbox.uncheck();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Typing correct value into input area test', async ({ page }) => {
+
+  test('Typing correct value into input area test', async ({}) => {
     // Given
     const inputText = 'test';
     const resultText = `Input value changed to: ${inputText}`;
@@ -51,19 +53,19 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     await simpleElementsWithIdsPage.input.fill(inputText);
     await simpleElementsWithIdsPage.input.blur();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Typing correct value into input area without blur test', async ({
-    page,
-  }) => {
+
+  test('Typing correct value into input area without blur test', async ({}) => {
     // Given
     const inputText = 'test';
     // When
     await simpleElementsWithIdsPage.input.fill(inputText);
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toBeEmpty;
+    await expect(simpleElementsWithIdsPage.resultsArea).toBeHidden();
   });
-  test('Typing too long value into input area test', async ({ page }) => {
+
+  test('Typing too long value into input area test', async ({}) => {
     // Given
     const inputText =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod';
@@ -74,10 +76,11 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     await simpleElementsWithIdsPage.input.fill(inputText);
     await simpleElementsWithIdsPage.input.blur();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Stretching the text area test', async ({ page }) => {
-    //
+
+  test('Stretching the text area test', async ({}) => {
+    // Given
     const boundingBoxBefore =
       await simpleElementsWithIdsPage.textArea.boundingBox();
     const startX = boundingBoxBefore.x + boundingBoxBefore.width - 5;
@@ -94,10 +97,15 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     const boundingBoxAfter =
       await simpleElementsWithIdsPage.textArea.boundingBox();
     // Then
-    expect(boundingBoxAfter.width).toBeGreaterThan(boundingBoxBefore.width);
-    expect(boundingBoxAfter.height).toBeGreaterThan(boundingBoxBefore.height);
+    expect
+      .soft(boundingBoxAfter.width)
+      .toBeGreaterThan(boundingBoxBefore.width);
+    expect
+      .soft(boundingBoxAfter.height)
+      .toBeGreaterThan(boundingBoxBefore.height);
   });
-  test('Typing correct value into text area test', async ({ page }) => {
+
+  test('Typing correct value into text area test', async ({}) => {
     // Given
     const inputText = 'test';
     const resultText = `Textarea value changed to: ${inputText}`;
@@ -105,9 +113,10 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     await simpleElementsWithIdsPage.textArea.fill(inputText);
     await simpleElementsWithIdsPage.textArea.blur();
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Dropdown list test', async ({ page }) => {
+
+  test('Dropdown list test', async ({}) => {
     // Given
     const options = ['option2', 'option3', 'option1'];
     const resultText = options.map((option) => `Selected option: ${option}`);
@@ -115,10 +124,13 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     for (let i = 0; i < options.length; i++) {
       await simpleElementsWithIdsPage.dropDownList.selectOption(options[i]);
       // Then
-      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+      await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(
+        resultText[i],
+      );
     }
   });
-  test('RadioButtons test', async ({ page }) => {
+
+  test('RadioButtons test', async ({}) => {
     // Given
     const radioButtons = [
       simpleElementsWithIdsPage.radioButtonFirst,
@@ -134,10 +146,13 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     for (let i = 0; i < radioButtons.length; i++) {
       await radioButtons[i].click();
       // Then
-      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+      await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(
+        resultText[i],
+      );
     }
   });
-  test('Range bar test', async ({ page }) => {
+
+  test('Range bar test', async ({}) => {
     // Given
     const ranges = ['50', '100', '0'];
     const resultText = ranges.map(
@@ -147,19 +162,23 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     for (let i = 0; i < ranges.length; i++) {
       await simpleElementsWithIdsPage.rangeBar.fill(ranges[i]);
       // Then
-      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+      await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(
+        resultText[i],
+      );
     }
   });
-  test('Label with mouse hover test', async ({ page }) => {
+
+  test('Label with mouse hover test', async ({}) => {
     // Given
     const resultText = 'Mouse over event occurred!';
     // When
     await simpleElementsWithIdsPage.tooltip.hover();
 
     // Then
-    expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
+    await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText);
   });
-  test('Select date test', async ({ page }) => {
+
+  test('Select date test', async ({}) => {
     // Given
     const dates = ['2024-06-05', '2022-02-09', '2023-04-02'];
     const resultText = dates.map((date) => `Selected date: ${date}`);
@@ -167,10 +186,13 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     for (let i = 0; i < dates.length; i++) {
       await simpleElementsWithIdsPage.dateInput.fill(dates[i]);
       // Then
-      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+      await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(
+        resultText[i],
+      );
     }
   });
-  test('Colors picker test', async ({ page }) => {
+
+  test('Colors picker test', async ({}) => {
     // Given
     const colors = ['#d02525', '#1a7431', '#e07ee7'];
     const resultText = colors.map(
@@ -183,7 +205,9 @@ test.describe('GUI tests for practice page - simple elements with IDs', () => {
     for (let i = 0; i < colors.length; i++) {
       await simpleElementsWithIdsPage.colorInput.fill(colors[i]);
       // Then
-      expect(simpleElementsWithIdsPage.resultsArea).toHaveText(resultText[i]);
+      await expect(simpleElementsWithIdsPage.resultsArea).toHaveText(
+        resultText[i],
+      );
     }
   });
 });


### PR DESCRIPTION
## Resolves #123

### Scope of changes:

- Added a new _SimpleElementsWithIdsPage_ class for managing locators and actions related to the "Simple Elements with IDs" subpage.

- Implemented a helper function _hexToRgb_ for converting HEX colors to RGB, located in the helpers directory.

- Added Playwright tests for the "Simple Elements with IDs" subpage, covering:

Filling input fields (text, date, color).
Clicking buttons and selecting radio buttons.
Testing tooltip visibility.
Testing the range bar behavior and textarea resizing.

     

### How to use it:
Run Playwright tests as usual.

## Any other comments?
--

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [x] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
