### PR TITLE
Create auto-reviewers-assign

### DIFF
--- a/.github/workflows/auto-reviewers-assign
+++ b/.github/workflows/auto-reviewers-assign
@@ -1,0 +1,16 @@
+name: Add Reviewers
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add Reviewers
+      uses: madrapps/add-reviewers@v1
+      with:
+        token: ${{ secrets.TOKEN }}
+        reviewers: kat-kan
+        re-request-when-approved: true
+        re-request-when-changes-requested: true

--- a/.github/workflows/auto-reviewers-assign
+++ b/.github/workflows/auto-reviewers-assign
@@ -2,6 +2,8 @@ name: Add Reviewers
 
 on:
   pull_request:
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/auto-reviewers-assign.yml
+++ b/.github/workflows/auto-reviewers-assign.yml
@@ -1,6 +1,7 @@
 name: Add Reviewers
 
 on:
+  workflow_dispatch:  
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/auto-reviewers-assign.yml
+++ b/.github/workflows/auto-reviewers-assign.yml
@@ -14,6 +14,6 @@ jobs:
       uses: madrapps/add-reviewers@v1
       with:
         token: ${{ secrets.TOKEN }}
-        reviewers: kat-kan
+        reviewers: kat-kan, Justyna-KO, Slawomir-DKl
         re-request-when-approved: true
         re-request-when-changes-requested: true


### PR DESCRIPTION
## Resolves #130 

### Scope of changes:

* Add workflow that enables automatic assign of reviewers for PR
* PR is still in "draft mode" as I wanted to test the solution and there is some work left (need to update list of default reviewers)

### How to use it:

After merging it will be triggered on each PR.

## Any other comments?

N/A

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [x] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
