### PR TITLE
[ISSUE-148] Modify the PATCH articles/{id} tests with title exceeding limit

### DIFF
--- a/tests/api/articles/articles-id-patch.spec.ts
+++ b/tests/api/articles/articles-id-patch.spec.ts
@@ -1,6 +1,5 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
 import { UserType } from '@_src_api/enums/user-types.enum';
-// import { logConsole } from '@_src_api/utils/log-levels';
 import { testUsers } from '@_src_fixtures_api/auth';
 import {
   createHeaders,
@@ -122,7 +121,7 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
   });
 
   test.describe('Trying to update existing article with title exceeding the length limit', async () => {
-    // Checking separately for regular and admin user, as in GAD < 2.7.11 admin could update article with title exceeding the length limit od 10000 chars
+    // Checking separately for regular and admin user, as in GAD < 2.7.11 admin could update article with title exceeding the length limit of 10000 chars
 
     const userTypes: string[] = [UserType.regular, UserType.admin];
     const newTitleExceedingLengthLimit = 'test'.repeat(10001);

--- a/tests/api/articles/articles-id-patch.spec.ts
+++ b/tests/api/articles/articles-id-patch.spec.ts
@@ -1,6 +1,6 @@
 import { HttpStatusCode } from '@_src_api/enums/api-status-code.enum';
 import { UserType } from '@_src_api/enums/user-types.enum';
-import { logConsole } from '@_src_api/utils/log-levels';
+// import { logConsole } from '@_src_api/utils/log-levels';
 import { testUsers } from '@_src_fixtures_api/auth';
 import {
   createHeaders,
@@ -10,19 +10,17 @@ import { APIResponse, expect, test } from '@playwright/test';
 
 test.describe('PATCH articles/{id} endpoint tests', async () => {
   const articles: string = `/api/articles`;
-  let setHeadersForRegularUser: { [key: string]: string };
+
   let setHeaders: { [key: string]: string };
   let randomNumber: string;
   let newTitle: string;
   const newContent =
     'Start with a Feature Description:\nBegin each Gherkin feature file with a high-level description\n of the feature you are testing. This provides context for the scenarios that follow\n Example: \nFeature: User Authentication \nAs a user,\nI want to be able to log in to my account,\nSo that I can access my personalized content.';
-  const newTitleExceedingLengthLimit = 'test'.repeat(10001);
 
   test.beforeAll(async () => {
     randomNumber = Math.random().toString();
     newTitle = `How to start writing effective test cases in Gherkin ${randomNumber}`;
     setHeaders = await createHeaders();
-    setHeadersForRegularUser = await createHeaders(UserType.regular);
   });
 
   test('Returns 200 OK when updating article', async ({ request }) => {
@@ -92,7 +90,7 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
 
     // When
     const response: APIResponse = await request.patch(`${articles}/2`, {
-      headers: setHeadersForRegularUser,
+      headers: setHeaders,
       data: {
         user_id: testUsers.regularUser.id,
         title: newTitle,
@@ -115,7 +113,7 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
 
     // When
     const response: APIResponse = await request.patch(`${articles}/1`, {
-      headers: setHeadersForRegularUser,
+      headers: setHeaders,
       data: malformedJson,
     });
 
@@ -123,48 +121,39 @@ test.describe('PATCH articles/{id} endpoint tests', async () => {
     expect(response.status()).toBe(HttpStatusCode.BadRequest);
   });
 
-  test('Returns 422 Unprocessable Entity when trying to update existing article with title exceeding the length limit', async ({
-    request,
-  }) => {
-    // Given
-    const expectedErrorMessage =
-      'One of field is invalid (empty, invalid or too long) or there are some additional fields: Field validation: "title" longer than "10000"';
+  test.describe('Trying to update existing article with title exceeding the length limit', async () => {
+    // Checking separately for regular and admin user, as in GAD < 2.7.11 admin could update article with title exceeding the length limit od 10000 chars
 
-    // When
-    const response: APIResponse = await request.patch(`${articles}/1`, {
-      headers: setHeadersForRegularUser,
-      data: {
-        user_id: testUsers.regularUser.id,
-        title: newTitleExceedingLengthLimit,
-      },
-    });
-    const body = await response.json();
+    const userTypes: string[] = [UserType.regular, UserType.admin];
+    const newTitleExceedingLengthLimit = 'test'.repeat(10001);
+    const dataBody: object = {
+      title: newTitleExceedingLengthLimit,
+    };
 
-    // Then
-    expect(response.status()).toBe(HttpStatusCode.UnprocessableEntity);
-    expect(body.error.message).toBe(expectedErrorMessage);
-  });
+    for (const userType of userTypes) {
+      if (userType === UserType.regular) {
+        dataBody['user_id'] = testUsers.regularUser.id;
+      }
 
-  test('Returns 200 OK when admin updates existing article with title exceeding the length limit set for regular users', async ({
-    request,
-  }) => {
-    // Given
-    const setHeadersForAdmin: { [key: string]: string } = await createHeaders(
-      UserType.admin,
-    );
+      test(`Returns 422 Unprocessable Entity for ${userType} user`, async ({
+        request,
+      }) => {
+        // Given
+        setHeaders = await createHeaders(userType);
+        const expectedErrorMessage =
+          'One of field is invalid (empty, invalid or too long) or there are some additional fields: Field validation: "title" longer than "10000"';
 
-    // When
-    const response: APIResponse = await request.patch(`${articles}/2`, {
-      headers: setHeadersForAdmin,
-      data: {
-        title: newTitleExceedingLengthLimit,
-      },
-    });
-    const body = await response.json();
-    logConsole(`Body after Admin patches article: ${body.title}`);
+        // When
+        const response: APIResponse = await request.patch(`${articles}/1`, {
+          headers: setHeaders,
+          data: dataBody,
+        });
+        const body = await response.json();
 
-    // Then
-    expect(response.status()).toBe(HttpStatusCode.Ok);
-    expect(body.title).toBe(newTitleExceedingLengthLimit);
+        // Then
+        expect(response.status()).toBe(HttpStatusCode.UnprocessableEntity);
+        expect(body.error.message).toBe(expectedErrorMessage);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Resolves #148 

### Scope of changes:

- Deleted separate test for admin
- Modified the test for regular user to be performed twice (once for regular user and once for the admin) - in `for` loop

### Notes

The change is quite important - without it the tests fail in CI/CD and we won't be able to merge new PRs.

Before submitting Pull Request, I've ensured that:

- [x] The PR is associated with the relevant Issue before its creation.
- [x] All new and existing tests passed
- [x] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
