### PR TITLE
[ISSUE-161] Add tests for GUI practise page: action on multiple checkboxes

### DIFF
--- a/src/gui/pages/practice-page.page.ts
+++ b/src/gui/pages/practice-page.page.ts
@@ -2,9 +2,11 @@ import { Locator, Page } from '@playwright/test';
 
 export class PracticePage {
   protected page: Page;
+  readonly resultsArea: Locator;
 
   constructor(page: Page) {
     this.page = page;
+    this.resultsArea = this.page.getByTestId('dti-results');
   }
 
   async textAreaStretching(

--- a/src/gui/pages/simple-elements-multiple-elements.page.ts
+++ b/src/gui/pages/simple-elements-multiple-elements.page.ts
@@ -3,14 +3,12 @@ import { Locator, Page } from '@playwright/test';
 
 export class SimpleElementsMultipleElements extends PracticePage {
   readonly checkboxes: Locator;
-  readonly resultsContainer: Locator;
   readonly resultsHistoryContainer: Locator;
 
   constructor(page: Page) {
     super(page);
 
     this.checkboxes = this.page.getByRole('checkbox');
-    this.resultsContainer = this.page.locator('#results');
     this.resultsHistoryContainer = this.page.locator(
       '#results-history-container',
     );
@@ -26,11 +24,11 @@ export class SimpleElementsMultipleElements extends PracticePage {
     await checkbox.uncheck();
   }
 
-  async getHistoryText(): Promise<string> {
-    return await this.resultsHistoryContainer.inputValue();
+  async getResultsText(): Promise<string> {
+    return await this.resultsArea.textContent();
   }
 
-  async getResultsText(): Promise<string> {
-    return await this.resultsContainer.textContent();
+  async getHistoryText(): Promise<string> {
+    return await this.resultsHistoryContainer.inputValue();
   }
 }

--- a/src/gui/pages/simple-elements-multiple-elements.page.ts
+++ b/src/gui/pages/simple-elements-multiple-elements.page.ts
@@ -1,0 +1,36 @@
+import { PracticePage } from './practice-page.page';
+import { Locator, Page } from '@playwright/test';
+
+export class SimpleElementsMultipleElements extends PracticePage {
+  readonly checkboxes: Locator;
+  readonly resultsContainer: Locator;
+  readonly resultsHistoryContainer: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.checkboxes = this.page.getByRole('checkbox');
+    this.resultsContainer = this.page.locator('#results');
+    this.resultsHistoryContainer = this.page.locator(
+      '#results-history-container',
+    );
+  }
+
+  async checkCheckbox(index: number): Promise<void> {
+    const checkbox = this.checkboxes.nth(index);
+    await checkbox.check();
+  }
+
+  async uncheckCheckbox(index: number): Promise<void> {
+    const checkbox = this.checkboxes.nth(index);
+    await checkbox.uncheck();
+  }
+
+  async getHistoryText(): Promise<string> {
+    return await this.resultsHistoryContainer.inputValue();
+  }
+
+  async getResultsText(): Promise<string> {
+    return await this.resultsContainer.textContent();
+  }
+}

--- a/src/gui/pages/simple-elements-with-ids.page.ts
+++ b/src/gui/pages/simple-elements-with-ids.page.ts
@@ -15,7 +15,6 @@ export class SimpleElementsWithIdsPage extends PracticePage {
   readonly tooltip: Locator;
   readonly dateInput: Locator;
   readonly colorInput: Locator;
-  readonly resultsArea: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -32,6 +31,5 @@ export class SimpleElementsWithIdsPage extends PracticePage {
     this.tooltip = this.page.getByTestId('dti-tooltip-element');
     this.dateInput = this.page.getByTestId('dti-date');
     this.colorInput = this.page.getByTestId('dti-color');
-    this.resultsArea = this.page.getByTestId('dti-results');
   }
 }

--- a/tests/gui/simple-elements/multiple-elements.spec.ts
+++ b/tests/gui/simple-elements/multiple-elements.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { SimpleElementsMultipleElements } from 'src/gui/pages/simple-elements-multiple-elements.page';
+
+test.describe('GUI tests for multiple elements', () => {
+  let simpleElementsMultipleElements: SimpleElementsMultipleElements;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/practice/simple-multiple-elements-no-ids.html');
+    simpleElementsMultipleElements = new SimpleElementsMultipleElements(page);
+  });
+
+  test('checkboxes - check, uncheck and history', async () => {
+    //Given
+    const numberOfElements =
+      await simpleElementsMultipleElements.checkboxes.count();
+
+    const expectedHistory = [];
+
+    for (let i = 0; i < numberOfElements; i++) {
+      const checkedText = `Checkbox is checked! (Opt ${i + 1}!)`;
+      const uncheckedText = `Checkbox is unchecked! (Opt ${i + 1}!)`;
+
+      // When
+      await simpleElementsMultipleElements.checkCheckbox(i);
+      expectedHistory.unshift(checkedText);
+
+      // Then
+      await expect(
+        await simpleElementsMultipleElements.getResultsText(),
+      ).toContain(checkedText);
+
+      const historyText = await simpleElementsMultipleElements.getHistoryText();
+      await expect(historyText).toContain(expectedHistory.join('\n'));
+
+      // When
+      await simpleElementsMultipleElements.uncheckCheckbox(i);
+      expectedHistory.unshift(uncheckedText);
+
+      // Then
+      await expect(
+        await simpleElementsMultipleElements.getResultsText(),
+      ).toContain(uncheckedText);
+
+      const historyTextAfterUncheck =
+        await simpleElementsMultipleElements.getHistoryText();
+      await expect(historyTextAfterUncheck).toContain(
+        expectedHistory.join('\n'),
+      );
+    }
+  });
+});

--- a/tests/gui/simple-elements/multiple-elements.spec.ts
+++ b/tests/gui/simple-elements/multiple-elements.spec.ts
@@ -20,32 +20,35 @@ test.describe('GUI tests for multiple elements', () => {
       const checkedText = `Checkbox is checked! (Opt ${i + 1}!)`;
       const uncheckedText = `Checkbox is unchecked! (Opt ${i + 1}!)`;
 
-      // When
-      await simpleElementsMultipleElements.checkCheckbox(i);
-      expectedHistory.unshift(checkedText);
+      await test.step(`Checking the checkbox Opt ${i + 1}`, async () => {
+        // When
+        await simpleElementsMultipleElements.checkCheckbox(i);
+        expectedHistory.unshift(checkedText);
 
-      // Then
-      await expect(
-        await simpleElementsMultipleElements.getResultsText(),
-      ).toContain(checkedText);
+        // Then
+        expect(await simpleElementsMultipleElements.getResultsText()).toContain(
+          checkedText,
+        );
 
-      const historyText = await simpleElementsMultipleElements.getHistoryText();
-      await expect(historyText).toContain(expectedHistory.join('\n'));
+        const historyText =
+          await simpleElementsMultipleElements.getHistoryText();
+        expect(historyText).toContain(expectedHistory.join('\n'));
+      });
 
-      // When
-      await simpleElementsMultipleElements.uncheckCheckbox(i);
-      expectedHistory.unshift(uncheckedText);
+      await test.step(`Unchecking the checkbox Opt ${i + 1}`, async () => {
+        // When
+        await simpleElementsMultipleElements.uncheckCheckbox(i);
+        expectedHistory.unshift(uncheckedText);
 
-      // Then
-      await expect(
-        await simpleElementsMultipleElements.getResultsText(),
-      ).toContain(uncheckedText);
+        // Then
+        expect(await simpleElementsMultipleElements.getResultsText()).toContain(
+          uncheckedText,
+        );
 
-      const historyTextAfterUncheck =
-        await simpleElementsMultipleElements.getHistoryText();
-      await expect(historyTextAfterUncheck).toContain(
-        expectedHistory.join('\n'),
-      );
+        const historyTextAfterUncheck =
+          await simpleElementsMultipleElements.getHistoryText();
+        expect(historyTextAfterUncheck).toContain(expectedHistory.join('\n'));
+      });
     }
   });
 });


### PR DESCRIPTION
## Resolves #161 

### Scope of changes:
Added a new SimpleElementsMultipleElements class for managing locators and actions related to the "Multiple elements without any ID or data-testid attributes" subpage.
Added Playwright tests for the "Multiple elements without any ID or data-testid attributes" subpage, covering action on multiple checkboxes and displaying the results.

### How to use it:

Run Playwright tests as usual.



Before submitting Pull Request, I've ensured that:

- [ ] The PR is associated with the relevant Issue before its creation.
- [ ] All new and existing tests passed
- [ ] My commit messages follow the `kawqa-gad-playwright` project's [git commit message format](https://github.com/kat-kan/kawqa-gad-playwright/blob/main/CONTRIBUTING.md).
